### PR TITLE
Fix typo in Cactus#setImage Javadoc

### DIFF
--- a/src/ChromeDinoHotseat/src/gameobject/Cactus.java
+++ b/src/ChromeDinoHotseat/src/gameobject/Cactus.java
@@ -124,7 +124,7 @@ public class Cactus extends Enemy{
     }
     /**
      * Setter dell'immagine del cactus.
-     * @param image L'immagine da sostuituire con quella precedente del cactus.
+     * @param image L'immagine da sostituire con quella precedente del cactus.
      */
     public void setImage(BufferedImage image){
         this.image = image;


### PR DESCRIPTION
## Summary
- fix misspelling "sostuituire" -> "sostituire" in `Cactus#setImage` Javadoc

## Testing
- `pre-commit` *(fails: no pre-commit configs found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e1bac5f88326bf389644a8e66c98