### PR TITLE
Fix typo in Ptera comment

### DIFF
--- a/src/ChromeDinoHotseat/src/gameobject/Ptera.java
+++ b/src/ChromeDinoHotseat/src/gameobject/Ptera.java
@@ -142,7 +142,7 @@ public class Ptera extends Enemy{
     
     /**
      * Ritorna lo stato della visibilità delle hitbox del dinosauro.
-     * @return lo stato della visibilità dekke hitbox del dinosauro.
+     * @return lo stato della visibilità delle hitbox del dinosauro.
      */
     public boolean getHitboxState(){
         return areHitboxVisible;


### PR DESCRIPTION
## Summary
- fix a typo in Ptera.java describing hitbox visibility

## Testing
- `ant -f src/ChromeDinoHotseat/build.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e189582483268750d3e7f4fc9a02